### PR TITLE
Fixing 30.1.1 beta2 (patch)release as the ansible collec github action failed at publishing it to ansible galaxy with error- (HTTP Code: 409, Message: Collection "vmware-alb-30.1.1" already exists. Code: conflict.collection_exists)

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,4 +18,4 @@ tags:
 - load
 - balancer
 - sdk
-version: 30.1.1
+version: 30.1.1-beta2


### PR DESCRIPTION
Fixing 30.1.1 beta2 release as the ansible collec github action failed at publishing it to ansible galaxy with error- (HTTP Code: 409, Message: Collection "vmware-alb-30.1.1" already exists. Code: conflict.collection_exists)