### PR TITLE
31.1.1Red hat fixex 31.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,1 +1,13 @@
 
+===========================
+vmware.alb Release Notes
+===========================
+
+
+v31.1.1
+======
+
+- AV-128581 - Added the installation of bs4 as a requirement to fix failure of auto… by @chandanapatnala in #160
+- Auto updated assets for ansible collection eng by @sagarpsalvi in [#178](https://github.com/vmware/ansible-collection-alb/pull/178)
+- Auto updated assets for ansible collection eng by @sagarpsalvi in [#195](https://github.com/vmware/ansible-collection-alb/pull/195)
+- AV-232916 Fixes ansible module doc by @Rohan-sss1 in [#222](https://github.com/vmware/ansible-collection-alb/pull/222)

--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ This collection has been tested against following Ansible versions: **>=2.15.0**
 
 ## Installation and Usage
 
-Ansible must be installed
-```
-pip install ansible
-```
-
 Install ALB collection using `ansible-galaxy` CLI:
 ```
 ansible-galaxy collection install vmware.alb
@@ -290,7 +285,7 @@ avi_config:
 
 GNU General Public License v2.0 or later.
 
-See [LICENSE](./LICENSE) to see the full text.
+See [LICENSE](https://github.com/vmware/ansible-collection-alb/blob/31.1.1/LICENSE) to see the full text.
 
 
 **Notes**

--- a/roles/aviconfig/meta/main.yml
+++ b/roles/aviconfig/meta/main.yml
@@ -1,0 +1,48 @@
+galaxy_info:
+  authors:
+  - Anurag Palsule <anurag.palsule@broadcom.com>
+  - Parikshit Manur <parikshit.manur@broadcom.com>
+  description: Ansible role to configure Avi
+  company: VMware
+  issue_tracker_url: https://github.com/vmware/ansible-collection-alb/issues
+  license: Apache-2.0
+  min_ansible_version: 2.15.0
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+    - name: Fedora
+      versions:
+        - 22
+        - 23
+        - 24
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - wily
+        - xenial
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
+        - wheezy
+
+  galaxy_tags:
+    - avi
+    - controller
+    - avicontroller
+    - avisdk
+    - avinetworks
+    - networking
+    - load
+    - balancer
+    - sdk
+    - lbaas
+    - lb
+    - virtualserver
+    - cloud
+    - loadbalancer
+    - gslb
+dependencies: []

--- a/roles/avicontroller/meta/main.yml
+++ b/roles/avicontroller/meta/main.yml
@@ -1,0 +1,31 @@
+---
+galaxy_info:
+  role_name: avicontroller
+  author:
+  - Anurag Palsule <anurag.palsule@broadcom.com>
+  - Parikshit Manur <parikshit.manur@broadcom.com>
+  description: Deploy's the AVI Vantage Controller
+  company: VMware
+  issue_tracker_url: https://github.com/vmware/ansible-collection-alb/issues
+  license: Apache-2.0
+  min_ansible_version: 2.15.0
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
+  galaxy_tags:
+    - avi
+    - controller
+    - loadbalancer
+    - avinetworks
+    - avicontroller
+    - centos
+    - ubuntu
+    - mesos
+dependencies: []

--- a/roles/avicontroller_csp/meta/main.yml
+++ b/roles/avicontroller_csp/meta/main.yml
@@ -1,0 +1,29 @@
+---
+galaxy_info:
+  role_name: avicontroller_csp
+  author:
+  - Anurag Palsule <anurag.palsule@broadcom.com>
+  - Parikshit Manur <parikshit.manur@broadcom.com>
+  description: Deploy's the AVI Vantage Controller on Cisco CSP
+  company: VMware
+  issue_tracker_url: https://github.com/vmware/ansible-collection-alb/issues
+  license: Apache-2.0
+  min_ansible_version: 2.15.0
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
+  galaxy_tags:
+    - avi
+    - controller
+    - loadbalancer
+    - avinetworks
+    - avicontroller
+    - csp
+dependencies: []

--- a/roles/avicontroller_kvm/meta/main.yml
+++ b/roles/avicontroller_kvm/meta/main.yml
@@ -1,0 +1,28 @@
+galaxy_info:
+  role_name: avicontroller-kvm
+  author:
+  - Anurag Palsule <anurag.palsule@broadcom.com>
+  - Parikshit Manur <parikshit.manur@broadcom.com>
+  description: Deploy's the AVI Vantage Controller on KVM
+  company: VMware
+  issue_tracker_url: https://github.com/vmware/ansible-collection-alb/issues
+  license: Apache-2.0
+  min_ansible_version: 2.15.0
+  platforms:
+  - name: EL
+    versions:
+    - 6
+    - 7
+  - name: Ubuntu
+    versions:
+    - precise
+    - trusty
+    - xenial
+  galaxy_tags:
+    - avi
+    - controller
+    - loadbalancer
+    - avinetworks
+    - avicontroller
+    - kvm
+dependencies: []

--- a/roles/avicontroller_vmware/meta/main.yml
+++ b/roles/avicontroller_vmware/meta/main.yml
@@ -1,0 +1,38 @@
+---
+galaxy_info:
+  role_name: avicontroller_vmware
+  author:
+  - Anurag Palsule <anurag.palsule@broadcom.com>
+  - Parikshit Manur <parikshit.manur@broadcom.com>
+  description: Ansible Role to setup Avi Controller on VMware
+  company: VMware
+  issue_tracker_url: https://github.com/vmware/ansible-collection-alb/issues
+  license: Apache-2.0
+  min_ansible_version: 2.15.0
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
+  galaxy_tags:
+    - avi
+    - controller
+    - avicontroller
+    - avisdk
+    - avinetworks
+    - networks
+    - load
+    - balancer
+    - sdk
+    - lbaas
+    - lb
+    - virtualserver
+    - cloud
+    - loadbalancer
+    - gslb
+dependencies: []

--- a/roles/avise/meta/main.yml
+++ b/roles/avise/meta/main.yml
@@ -1,0 +1,35 @@
+---
+galaxy_info:
+  role_name: avise
+  author:
+  - Anurag Palsule <anurag.palsule@broadcom.com>
+  - Parikshit Manur <parikshit.manur@broadcom.com>
+  description: Deploy's the AVI Vantage Service Engine
+  company: VMware
+  issue_tracker_url: https://github.com/vmware/ansible-collection-alb/issues
+  license: Apache-2.0
+  min_ansible_version: 2.15.0
+  github_branch: master
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
+        - focal
+  galaxy_tags:
+    - avi
+    - serviceengine
+    - loadbalancer
+    - service
+    - engine
+    - avinetworks
+    - avise
+    - centos
+    - ubuntu
+    - mesos
+dependencies: []

--- a/roles/avise/tasks/docker/autoregistration.yml
+++ b/roles/avise/tasks/docker/autoregistration.yml
@@ -37,7 +37,7 @@
   when: se_version is defined
 
 - name: Avi SE | Autoregistration | Get the cloud uuid from se_cloud_name
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_leader_ctl_ip }}"
     username: "{{ se_leader_ctl_username }}"
     password: "{{ se_leader_ctl_password }}"
@@ -50,7 +50,7 @@
   delegate_to: localhost
 
 - name: Avi SE | Autoregistration | Get a token from the Avi Controller
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_leader_ctl_ip }}"
     username: "{{ se_leader_ctl_username }}"
     password: "{{ se_leader_ctl_password }}"
@@ -70,7 +70,7 @@
 - debug: msg="Recieved Authentication {{ se_auth_token }} from {{ se_leader_ctl_ip }}"
 
 - name: Avi SE | Autoregistration | Get a se group uuid of {{ se_group_name }} from the Avi Controller
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_leader_ctl_ip }}"
     username: "{{ se_leader_ctl_username }}"
     password: "{{ se_leader_ctl_password }}"

--- a/roles/avise_csp/meta/main.yml
+++ b/roles/avise_csp/meta/main.yml
@@ -1,0 +1,35 @@
+galaxy_info:
+  role_name: avise_csp
+  author:
+  - Anurag Palsule <anurag.palsule@broadcom.com>
+  - Parikshit Manur <parikshit.manur@broadcom.com>
+  description: Ansible Role to setup Avi Service Engine on CSP Cloud
+  company: VMware
+  license: Apache-2.0
+  issue_tracker_url: https://github.com/vmware/ansible-collection-alb/issues
+  min_ansible_version: 2.15.0
+  platforms:
+  - name: Ubuntu
+    versions:
+    - precise
+    - trusty
+    - xenial
+  galaxy_tags:
+    - avi
+    - controller
+    - avicontroller
+    - avisdk
+    - avinetworks
+    - networks
+    - load
+    - balancer
+    - sdk
+    - lbaas
+    - lb
+    - virtualserver
+    - cloud
+    - loadbalancer
+    - gslb
+    - csp
+    - cisco
+dependencies: []

--- a/roles/avise_kvm/meta/main.yml
+++ b/roles/avise_kvm/meta/main.yml
@@ -1,0 +1,35 @@
+---
+galaxy_info:
+  role_name: avise_kvm
+  author:
+  - Anurag Palsule <anurag.palsule@broadcom.com>
+  - Parikshit Manur <parikshit.manur@broadcom.com>
+  description: Ansible Role to setup Avi Service Engine on KVM
+  company: VMware
+  issue_tracker_url: https://github.com/vmware/ansible-collection-alb/issues
+  license: Apache-2.0
+  min_ansible_version: 2.15.0
+  platforms:
+  - name: Ubuntu
+    versions:
+    - precise
+    - trusty
+    - xenial
+  galaxy_tags:
+    - avi
+    - controller
+    - avicontroller
+    - avisdk
+    - avinetworks
+    - networks
+    - load
+    - balancer
+    - sdk
+    - lbaas
+    - lb
+    - virtualserver
+    - cloud
+    - loadbalancer
+    - gslb
+    - kvm
+dependencies: []

--- a/roles/avise_kvm/tasks/deploy_se.yml
+++ b/roles/avise_kvm/tasks/deploy_se.yml
@@ -102,7 +102,7 @@
     - "{{ ci_iso }}"
 
 - name: "Avi SE | KVM | Verify SE connected to controller"
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_kvm_ctrl_ip }}"
     username: "{{ se_kvm_ctrl_username }}"
     password: "{{ se_kvm_ctrl_password }}"
@@ -120,7 +120,7 @@
 
 - block:
   - name: Avi SE | KVM | Service deploy | Configure vnic ips
-    avi_update_se_data_vnics:
+    vmware.alb.avi_update_se_data_vnics:
       controller: "{{ se_kvm_ctrl_ip }}"
       username: "{{ se_kvm_ctrl_username }}"
       password: "{{ se_kvm_ctrl_password }}"

--- a/roles/avise_kvm/tasks/requirements.yml
+++ b/roles/avise_kvm/tasks/requirements.yml
@@ -66,7 +66,7 @@
    mode: 0644
 
 - name: "Avi SE | KVM | Get the cloud uuid from Default-Cloud"
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_kvm_ctrl_ip }}"
     username: "{{ se_kvm_ctrl_username }}"
     password: "{{ se_kvm_ctrl_password }}"
@@ -79,7 +79,7 @@
   delegate_to: localhost
 
 - name: "Avi SE | KVM | Get a token from the Avi Controller"
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_kvm_ctrl_ip }}"
     username: "{{ se_kvm_ctrl_username }}"
     password: "{{ se_kvm_ctrl_password }}"
@@ -92,7 +92,7 @@
   delegate_to: localhost
 
 - name: "Avi SE | KVM | Image deploy | generate SE image on the controller"
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_kvm_ctrl_ip }}"
     username: "{{ se_kvm_ctrl_username }}"
     password: "{{ se_kvm_ctrl_password }}"
@@ -106,7 +106,7 @@
   delegate_to: localhost
 
 - name: "Avi SE | KVM | Get the se.qcow2 from the Avi Controller"
-  avi_api_fileservice:
+  vmware.alb.avi_api_fileservice:
     controller: "{{ se_kvm_ctrl_ip }}"
     username: "{{ se_kvm_ctrl_username }}"
     password: "{{ se_kvm_ctrl_password }}"

--- a/roles/avise_vmware/meta/main.yml
+++ b/roles/avise_vmware/meta/main.yml
@@ -1,0 +1,36 @@
+galaxy_info:
+  role_name: avise_vmware
+  author:
+  - Anurag Palsule <anurag.palsule@broadcom.com>
+  - Parikshit Manur <parikshit.manur@broadcom.com>
+  description: Ansible Role to setup Avi Service Engine on VMware
+  company: VMware
+  license: Apache-2.0
+  issue_tracker_url: https://github.com/vmware/ansible-collection-alb/issues
+  min_ansible_version: 2.15.0
+  platforms:
+  - name: Ubuntu
+    versions:
+    - precise
+    - trusty
+    - xenial
+  galaxy_tags:
+    - avi
+    - service
+    - engine
+    - avise
+    - avisdk
+    - avinetworks
+    - networks
+    - load
+    - balancer
+    - sdk
+    - lbaas
+    - lb
+    - virtualserver
+    - cloud
+    - loadbalancer
+    - gslb
+    - vmware
+    - vcenter
+dependencies: []

--- a/roles/avise_vmware/tasks/autoregistration.yml
+++ b/roles/avise_vmware/tasks/autoregistration.yml
@@ -13,7 +13,7 @@
     - se_leader_ctl_version
 
 - name: Avi SE | Autoregistration | Get the cloud uuid from se_cloud_name
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_leader_ctl_ip }}"
     username: "{{ se_leader_ctl_username }}"
     password: "{{ se_leader_ctl_password }}"
@@ -25,7 +25,7 @@
   delegate_to: localhost
 
 - name: Avi SE | Autoregistration | Get the cluster uuid from /api/cluster/status
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_leader_ctl_ip }}"
     username: "{{ se_leader_ctl_username }}"
     password: "{{ se_leader_ctl_password }}"
@@ -37,7 +37,7 @@
   delegate_to: localhost
 
 - name: Avi SE | Autoregistration | Get a token from the Avi Controller
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_leader_ctl_ip }}"
     username: "{{ se_leader_ctl_username }}"
     password: "{{ se_leader_ctl_password }}"

--- a/roles/avise_vmware/tasks/destroy_se.yml
+++ b/roles/avise_vmware/tasks/destroy_se.yml
@@ -27,7 +27,7 @@
     query: "[?guest_name=='{{ se_vmw_vm_name }}']"
 
 - name: Avi SE | VMware | Destroy SE VM
-  deploy_se:
+  vmware.alb.deploy_se:
     ovftool_path: '{{ ovftool_path }}'
     vcenter_host: '{{ vcenter_host }}'
     vcenter_user: '{{ vcenter_user }}'
@@ -48,7 +48,7 @@
   delegate_to: localhost
 
 - name: Avi SE | VMware | Service destroy | Verify SE disconnection
-  avi_api_session:
+  vmware.alb.avi_api_session:
     controller: "{{ se_leader_ctl_ip }}"
     username: "{{ se_leader_ctl_username }}"
     password: "{{ se_leader_ctl_password }}"
@@ -64,7 +64,7 @@
   delegate_to: localhost
 
 - name:  Avi SE | VMware | Service destroy | Delete SE from controller
-  avi_serviceengine:
+  vmware.alb.avi_serviceengine:
     controller: '{{ se_leader_ctl_ip }}'
     username: '{{ se_leader_ctl_username }}'
     password: '{{ se_leader_ctl_password }}'

--- a/roles/avise_vmware/tasks/main.yml
+++ b/roles/avise_vmware/tasks/main.yml
@@ -35,7 +35,7 @@
       when: se_ova_deploy
 
     - name: Avi SE | Verify non default se group is available
-      avi_api_session:
+      vmware.alb.avi_api_session:
         controller: "{{ se_leader_ctl_ip }}"
         username: "{{ se_leader_ctl_username }}"
         password: "{{ se_leader_ctl_password }}"
@@ -49,7 +49,7 @@
 
 
     - name: Avi SE | VMware | Deploy SE VM
-      deploy_se:
+      vmware.alb.deploy_se:
         ovftool_path: '{{ ovftool_path }}'
         vcenter_host: '{{ vcenter_host }}'
         vcenter_user: '{{ vcenter_user }}'
@@ -81,7 +81,7 @@
       delegate_to: localhost
 
     - name: Avi SE | Verify SE Deployment
-      verify_se:
+      vmware.alb.verify_se:
         se_leader_ctl_ip: '{{ se_leader_ctl_ip }}'
         se_leader_ctl_username: '{{ se_leader_ctl_username }}'
         se_leader_ctl_password: '{{ se_leader_ctl_password }}'
@@ -102,7 +102,7 @@
     - debug: msg={{ verify_output.msg }}
 
     - name: Avi SE | Attach SE to SE group
-      avi_api_session:
+      vmware.alb.avi_api_session:
         controller: "{{ se_leader_ctl_ip }}"
         username: "{{ se_leader_ctl_username }}"
         password: "{{ se_leader_ctl_password }}"

--- a/roles/avise_vmware/tasks/ova_deploy.yml
+++ b/roles/avise_vmware/tasks/ova_deploy.yml
@@ -9,7 +9,7 @@
 
 - block:
     - name:  Avi SE | VMware | Image deploy | Genarate SE image if not exist on controller
-      avi_api_session:
+      vmware.alb.avi_api_session:
         controller: '{{ se_leader_ctl_ip }}'
         username: '{{ se_leader_ctl_username }}'
         password: '{{ se_leader_ctl_password }}'
@@ -32,7 +32,7 @@
   delegate_to: localhost
 
 - name: Avi SE | VMware | Image Deploy | Get SE image on Local
-  avi_api_fileservice:
+  vmware.alb.avi_api_fileservice:
     controller: '{{ se_leader_ctl_ip }}'
     username: '{{ se_leader_ctl_username }}'
     password: '{{ se_leader_ctl_password }}'


### PR DESCRIPTION
Changes suggested by RED HAT Team


* pip install ansible is in the readme and needs to be removed.
* license link is github-relative - this needs to be in the format of [LICENSE](full github url) to work in Automation Hub.
* import log problem Could not get role description, no role metadata found - The collection doesn’t have meta/ directory with a main.yml file in each role entry. This file should be at: <collection_root>/roles/<rolename>/meta/main.yml.
* Substantial number of ansible-lint problems
* no changelog in tarball or repo.